### PR TITLE
fix: use unix-style paths in output to minimize git diffs

### DIFF
--- a/src/typescript/helpers.ts
+++ b/src/typescript/helpers.ts
@@ -6,9 +6,10 @@ import {type ArrayTypeNode, type UnionTypeNode} from 'groq-js'
 
 import {RESERVED_IDENTIFIERS} from './constants.js'
 
-export function normalizePath(root: string, filename: string) {
+export function normalizePrintablePath(root: string, filename: string) {
   const resolved = path.resolve(root, filename)
-  return path.relative(root, resolved)
+  // Always use Unix-style paths for consistent output across platforms
+  return path.relative(root, resolved).replaceAll('\\', '/')
 }
 
 function sanitizeIdentifier(input: string): string {

--- a/src/typescript/typeGenerator.ts
+++ b/src/typescript/typeGenerator.ts
@@ -13,7 +13,12 @@ import {
   INTERNAL_REFERENCE_SYMBOL,
   SANITY_QUERIES,
 } from './constants.js'
-import {computeOnce, generateCode, getUniqueIdentifierForName, normalizePath} from './helpers.js'
+import {
+  computeOnce,
+  generateCode,
+  getUniqueIdentifierForName,
+  normalizePrintablePath,
+} from './helpers.js'
 import {SchemaTypeGenerator} from './schemaTypeGenerator.js'
 import {
   type EvaluatedModule,
@@ -92,7 +97,7 @@ export class TypeGenerator {
 
         if (index === 0 && schemaPath) {
           ast = t.addComments(ast, 'leading', [
-            {type: 'CommentLine', value: ` Source: ${normalizePath(root, schemaPath)}`},
+            {type: 'CommentLine', value: ` Source: ${normalizePrintablePath(root, schemaPath)}`},
           ])
         }
         const code = generateCode(ast)
@@ -183,7 +188,7 @@ export class TypeGenerator {
           const typeAlias = t.tsTypeAliasDeclaration(id, null, tsType)
           const trimmedQuery = extractedQuery.query.replaceAll(/(\r\n|\n|\r)/gm, '').trim()
           const ast = t.addComments(t.exportNamedDeclaration(typeAlias), 'leading', [
-            {type: 'CommentLine', value: ` Source: ${normalizePath(root, filename)}`},
+            {type: 'CommentLine', value: ` Source: ${normalizePrintablePath(root, filename)}`},
             {type: 'CommentLine', value: ` Variable: ${variable.id.name}`},
             {type: 'CommentLine', value: ` Query: ${trimmedQuery}`},
           ])


### PR DESCRIPTION
### Description

If a team has people using a mix of windows/unix, you may end up with a lot of git diffs in the output paths:

<img width="648" height="76" alt="image" src="https://github.com/user-attachments/assets/f38bab3f-3dd4-4f72-9d49-ad986384bd88" />

Since the path is only used for display purposes, it is safe to just use one style - would assume that people are comfortable with reading paths in either style, but went for unix since it's very common for developers.

Note: I went for replacing slashes rather than using `path.posix.X` since we want the path operations to work the same as they do now - we only want the _displayed_ path to be in a different format. To make that clearer, I also renamed the function from `normalizePath` to `normalizePrintablePath`.

### What to review

Changes make sense?

### Testing

We should probably throw Windows into the text matrix? That might actually reveal this issue.
