### PR TITLE
fix(cli): fixes issue with missing config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dist",
     "bin",
     "oclif.manifest.json",
+    "oclif.config.js",
     "babel.config.json"
   ],
   "scripts": {


### PR DESCRIPTION
Missed the oclif.config.js in package.json files 