### PR TITLE
fix: export the typegen command for internal use

### DIFF
--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -1,3 +1,4 @@
+export {TypegenGenerateCommand} from '../commands/typegen/generate.js'
 export {
   type CodegenConfig,
   configDefinition,

--- a/src/commands/typegen/generate.ts
+++ b/src/commands/typegen/generate.ts
@@ -42,6 +42,9 @@ ${chalk.bold('Note:')}
 
 const debug = subdebug('typegen:generate')
 
+/**
+ * @internal
+ */
 export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerateCommand> {
   static override description = description
 


### PR DESCRIPTION
Exports it so we can use it in old CLI