### PR TITLE
feat: allow calling generation with partial or no typegen config (fallback to defaults)

### DIFF
--- a/src/actions/streamProcessor.ts
+++ b/src/actions/streamProcessor.ts
@@ -5,12 +5,13 @@ import {spinner} from '@sanity/cli-core/ux'
 import {WorkerChannelReceiver} from '@sanity/worker-channels'
 import {format, resolveConfig as resolvePrettierConfig} from 'prettier'
 
+import {TypeGenConfig} from '../readConfig.js'
 import {count} from '../utils/count.js'
 import {formatPath} from '../utils/formatPath.js'
 import {getMessage} from '../utils/getMessage.js'
 import {percent} from '../utils/percent.js'
 import {generatedFileWarning} from './generatedFileWarning.js'
-import {type RunTypegenOptions, TypegenWorkerChannel} from './types.js'
+import {TypegenWorkerChannel} from './types.js'
 
 /**
  * Processes the event stream from a typegen worker thread.
@@ -24,7 +25,7 @@ import {type RunTypegenOptions, TypegenWorkerChannel} from './types.js'
  */
 export async function processTypegenWorkerStream(
   receiver: WorkerChannelReceiver<TypegenWorkerChannel>,
-  options: RunTypegenOptions['config'],
+  options: TypeGenConfig,
 ) {
   const start = Date.now()
   const {formatGeneratedCode, generates, schema} = options

--- a/src/actions/typegenGenerate.ts
+++ b/src/actions/typegenGenerate.ts
@@ -6,6 +6,7 @@ import {Worker} from 'node:worker_threads'
 
 import {WorkerChannelReceiver} from '@sanity/worker-channels'
 
+import {prepareConfig} from '../utils/config.js'
 import {processTypegenWorkerStream} from './streamProcessor.js'
 import {
   type GenerationResult,
@@ -26,7 +27,8 @@ import {
 export async function runTypegenGenerate(options: RunTypegenOptions): Promise<GenerationResult> {
   const {config, workDir} = options
 
-  const {formatGeneratedCode, generates, overloadClientMethods, path, schema} = config
+  const {formatGeneratedCode, generates, overloadClientMethods, path, schema} =
+    prepareConfig(config)
 
   const outputPath = isAbsolute(generates) ? generates : join(workDir, generates)
 

--- a/src/actions/typegenWatch.ts
+++ b/src/actions/typegenWatch.ts
@@ -5,6 +5,7 @@ import chokidar, {FSWatcher} from 'chokidar'
 import {debounce, mean} from 'lodash-es'
 
 import {TypegenWatchModeTraceAttributes} from '../typegen.telemetry.js'
+import {prepareConfig} from '../utils/config.js'
 import {runTypegenGenerate} from './typegenGenerate.js'
 import {type RunTypegenOptions} from './types.js'
 
@@ -77,7 +78,7 @@ export function runTypegenWatcher(options: RunTypegenOptions): {
   watcher: FSWatcher
 } {
   const {config, workDir} = options
-  const {path, schema} = config
+  const {path, schema} = prepareConfig(config)
 
   const stats = {
     failedCount: 0,

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -39,11 +39,11 @@ export type TypegenWorkerChannel = WorkerChannel.Definition<
  * This is the programmatic API for one-off generation without file watching.
  */
 export interface RunTypegenOptions {
-  /** Typegen configuration */
-  config: TypeGenConfig
-
   /** Working directory (usually project root) */
   workDir: string
+
+  /** Typegen configuration */
+  config?: Partial<TypeGenConfig>
 
   /** Optional spinner instance for progress display */
   spin?: ReturnType<typeof spinner>

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest'
+
+import {prepareConfig} from '../config.js'
+
+describe('prepareConfig', () => {
+  it('returns default values when called with undefined', () => {
+    const config = prepareConfig(undefined)
+
+    expect(config).toEqual({
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      overloadClientMethods: false,
+      path: './src/**/*.{ts,tsx,js,jsx}',
+      schema: 'schema.json',
+    })
+  })
+
+  it('returns default values when called with empty object', () => {
+    const config = prepareConfig({})
+
+    expect(config).toEqual({
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      overloadClientMethods: false,
+      path: './src/**/*.{ts,tsx,js,jsx}',
+      schema: 'schema.json',
+    })
+  })
+
+  it('preserves provided values', () => {
+    const config = prepareConfig({
+      formatGeneratedCode: true,
+      generates: 'custom.types.ts',
+      overloadClientMethods: true,
+      path: './custom/**/*.ts',
+      schema: 'custom-schema.json',
+    })
+
+    expect(config).toEqual({
+      formatGeneratedCode: true,
+      generates: 'custom.types.ts',
+      overloadClientMethods: true,
+      path: './custom/**/*.ts',
+      schema: 'custom-schema.json',
+    })
+  })
+
+  it('merges partial config with defaults', () => {
+    const config = prepareConfig({
+      formatGeneratedCode: true,
+      generates: 'my-types.ts',
+    })
+
+    expect(config).toEqual({
+      formatGeneratedCode: true,
+      generates: 'my-types.ts',
+      overloadClientMethods: false,
+      path: './src/**/*.{ts,tsx,js,jsx}',
+      schema: 'schema.json',
+    })
+  })
+
+  it('handles explicit false values correctly', () => {
+    const config = prepareConfig({
+      formatGeneratedCode: false,
+      overloadClientMethods: false,
+    })
+
+    expect(config.formatGeneratedCode).toBe(false)
+    expect(config.overloadClientMethods).toBe(false)
+  })
+})

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,11 @@
+import {TypeGenConfig} from '../readConfig.js'
+
+export function prepareConfig(config?: Partial<TypeGenConfig>): TypeGenConfig {
+  return {
+    formatGeneratedCode: config?.formatGeneratedCode ?? false,
+    generates: config?.generates ?? 'sanity.types.ts',
+    overloadClientMethods: config?.overloadClientMethods ?? false,
+    path: config?.path ?? './src/**/*.{ts,tsx,js,jsx}',
+    schema: config?.schema ?? 'schema.json',
+  }
+}


### PR DESCRIPTION
### TL;DR

Made the typegen configuration optional by implementing default values.

### What changed?

- Added a new `prepareConfig` utility function that provides default values for the typegen configuration
- Modified the `config` parameter in `RunTypegenOptions` to be optional and partial
- Updated the typegen generate and watch actions to use the new `prepareConfig` function

### How to test?

1. Verify that typegen works with a partial configuration object
2. Confirm that typegen works without any configuration (using all defaults)
3. Run the new tests with `vitest src/utils/__tests__/config.test.ts`
4. Ensure existing functionality still works with complete configuration objects

### Why make this change?

This change improves the developer experience by making the typegen configuration more flexible. Users can now omit configuration options and rely on sensible defaults, reducing boilerplate in simple use cases. The implementation also ensures backward compatibility with existing code that provides full configuration.