### PR TITLE
feat: support doc type used as field type

### DIFF
--- a/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -47,3 +47,45 @@ export type STRANGE_QUERY_RESULT = Array<{
 
 "
 `;
+
+exports[`TypeGenerator > regression: support using document type as field type 1`] = `
+"export type Hero = {
+  _id: string;
+  _type: "hero";
+  title: string;
+};
+
+export type Page = {
+  _id: string;
+  _type: "page";
+  pageContent: Array<{
+    _key: string;
+  } & Hero>;
+  title: string;
+};
+
+export type AllSanitySchemaTypes = Hero | Page;
+
+export declare const internalGroqTypeReferenceTo: unique symbol;
+
+// Source: ../../../../../src/queries.ts
+// Variable: DOC_TYPE_SPREAD_FIELD_QUERY
+// Query: *[_type == "page"].pageContent[]{...}[].title
+export type DOC_TYPE_SPREAD_FIELD_QUERY_RESULT = Array<string>;
+
+// Source: ../../../../../src/queries.ts
+// Variable: DOC_TYPE_FIELD_QUERY
+// Query: *[_type == "page"].pageContent[].title
+export type DOC_TYPE_FIELD_QUERY_RESULT = Array<string>;
+
+// Query TypeMap
+import "@sanity/client";
+declare module "@sanity/client" {
+  interface SanityQueries {
+    "*[_type == \\"page\\"].pageContent[]{...}[].title": DOC_TYPE_SPREAD_FIELD_QUERY_RESULT;
+    "*[_type == \\"page\\"].pageContent[].title": DOC_TYPE_FIELD_QUERY_RESULT;
+  }
+}
+
+"
+`;


### PR DESCRIPTION
### Description

Add a test to guard against future regressions in support for using doc types as the type for fields in the schema.

The Sanity studio currently supports using a document type as a field type. After getting #45 from a user using document types as field types I found that it was not supported in codegen.

There's a PR open for fixing the underlying issue in [`groq-js`](https://github.com/sanity-io/groq-js/issues/326).

CLDX-4774

> **PENDING UPSTREAM RELEASE**
> This test will not pass before we have a version of `groq-js` with the fix in it.

### What to review

Nothing but the new test.