### PR TITLE
fix: filter out `unknown` from type unions

### DIFF
--- a/src/typescript/__tests__/schemaTypeGenerator.test.ts
+++ b/src/typescript/__tests__/schemaTypeGenerator.test.ts
@@ -218,7 +218,7 @@ describe(SchemaTypeGenerator.name, () => {
       expect(generateCode(booleanLiteralAlias)).toMatchInlineSnapshot(`"true"`)
     })
 
-    test('generates TS Types for unknown', () => {
+    test('does not emit type alias for a type that resolves to unknown', () => {
       const schema = new SchemaTypeGenerator([
         {
           name: 'unknownAlias',
@@ -229,9 +229,8 @@ describe(SchemaTypeGenerator.name, () => {
         },
       ])
 
-      const unknownAlias = schema.getType('unknownAlias')?.tsType
-
-      expect(generateCode(unknownAlias)).toMatchInlineSnapshot(`"unknown"`)
+      expect(schema.getType('unknownAlias')).toBeUndefined()
+      expect([...schema]).toHaveLength(0)
     })
 
     test('generates TS Types for null', () => {
@@ -328,6 +327,308 @@ describe(SchemaTypeGenerator.name, () => {
       expect(t.isTSStringKeyword(unionOfOneAlias)).toBe(true)
     })
 
+    test('filters unknown members from unions that also have concrete types', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'unionWithUnknowns',
+          type: 'type',
+          value: {
+            of: [{type: 'string'}, {type: 'unknown'}, {type: 'number'}, {type: 'unknown'}],
+            type: 'union',
+          },
+        },
+        {
+          name: 'allUnknownUnion',
+          type: 'type',
+          value: {of: [{type: 'unknown'}, {type: 'unknown'}], type: 'union'},
+        },
+        {
+          name: 'singleConcreteWithUnknown',
+          type: 'type',
+          value: {of: [{type: 'string'}, {type: 'unknown'}], type: 'union'},
+        },
+      ])
+
+      expect(generateCode(schema.getType('unionWithUnknowns')?.tsType)).toMatchInlineSnapshot(
+        `"string | number"`,
+      )
+      expect(schema.getType('allUnknownUnion')).toBeUndefined()
+      expect(
+        generateCode(schema.getType('singleConcreteWithUnknown')?.tsType),
+      ).toMatchInlineSnapshot(`"string"`)
+    })
+
+    test('filters unknown from unions where object members collapse to unknown via unresolvable inline rest', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'resolvedType',
+          type: 'type',
+          value: {
+            attributes: {
+              _type: {type: 'objectAttribute', value: {type: 'string', value: 'resolved'}},
+            },
+            type: 'object',
+          },
+        },
+        {
+          name: 'arrayWithCollapsedUnknown',
+          type: 'type',
+          value: {
+            of: {
+              of: [
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'resolvedType', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'nonExistentType', type: 'inline'},
+                  type: 'object',
+                },
+              ],
+              type: 'union',
+            },
+            type: 'array',
+          },
+        },
+      ])
+
+      const code = generateCode(schema.getType('arrayWithCollapsedUnknown')?.tsType)
+      expect(code).not.toContain('unknown')
+      expect(code).toContain('ResolvedType')
+    })
+
+    test('BlockContent-style union: objects with unresolvable inline rest do not collapse the entire array type to unknown', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'ctaCollection',
+          type: 'type',
+          value: {
+            attributes: {
+              _type: {
+                type: 'objectAttribute',
+                value: {type: 'string', value: 'ctaCollection'},
+              },
+            },
+            type: 'object',
+          },
+        },
+        {
+          name: 'gist',
+          type: 'type',
+          value: {
+            attributes: {
+              _type: {type: 'objectAttribute', value: {type: 'string', value: 'gist'}},
+              url: {optional: true, type: 'objectAttribute', value: {type: 'string'}},
+            },
+            type: 'object',
+          },
+        },
+        {
+          name: 'blockContent',
+          type: 'type',
+          value: {
+            of: {
+              of: [
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'ctaCollection', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'gist', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'infoBox', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'gotcha', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _key: {type: 'objectAttribute', value: {type: 'string'}},
+                  },
+                  rest: {name: 'protip', type: 'inline'},
+                  type: 'object',
+                },
+                {
+                  attributes: {
+                    _type: {
+                      type: 'objectAttribute',
+                      value: {type: 'string', value: 'block'},
+                    },
+                    children: {
+                      optional: true,
+                      type: 'objectAttribute',
+                      value: {
+                        of: {
+                          attributes: {
+                            _type: {
+                              type: 'objectAttribute',
+                              value: {type: 'string', value: 'span'},
+                            },
+                            marks: {
+                              optional: true,
+                              type: 'objectAttribute',
+                              value: {of: {type: 'string'}, type: 'array'},
+                            },
+                            text: {
+                              optional: true,
+                              type: 'objectAttribute',
+                              value: {type: 'string'},
+                            },
+                          },
+                          rest: {
+                            attributes: {
+                              _key: {type: 'objectAttribute', value: {type: 'string'}},
+                            },
+                            type: 'object',
+                          },
+                          type: 'object',
+                        },
+                        type: 'array',
+                      },
+                    },
+                    style: {
+                      optional: true,
+                      type: 'objectAttribute',
+                      value: {
+                        of: [
+                          {type: 'string', value: 'normal'},
+                          {type: 'string', value: 'h2'},
+                        ],
+                        type: 'union',
+                      },
+                    },
+                  },
+                  rest: {
+                    attributes: {
+                      _key: {type: 'objectAttribute', value: {type: 'string'}},
+                    },
+                    type: 'object',
+                  },
+                  type: 'object',
+                },
+              ],
+              type: 'union',
+            },
+            type: 'array',
+          },
+        },
+      ])
+
+      const blockContentType = schema.getType('blockContent')
+      expect(blockContentType).toBeDefined()
+
+      const code = generateCode(blockContentType!.tsType)
+
+      expect(code).not.toMatch(/\bunknown\b/)
+      expect(code).toContain('CtaCollection')
+      expect(code).toContain('Gist')
+      expect(code).toContain('"block"')
+    })
+
+    test('does not emit type aliases for types that resolve to unknown', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'concreteType',
+          type: 'type',
+          value: {
+            attributes: {
+              name: {type: 'objectAttribute', value: {type: 'string'}},
+            },
+            type: 'object',
+          },
+        },
+        {
+          name: 'unknownType',
+          type: 'type',
+          value: {type: 'unknown'},
+        },
+      ])
+
+      const emitted = [...schema]
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]!.name).toBe('concreteType')
+      expect(schema.getType('unknownType')).toBeUndefined()
+    })
+
+    test('does not emit type aliases for types that resolve to Array<unknown>', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'concreteType',
+          type: 'type',
+          value: {type: 'string'},
+        },
+        {
+          name: 'unknownArrayType',
+          type: 'type',
+          value: {
+            of: {of: [{type: 'unknown'}, {type: 'unknown'}], type: 'union'},
+            type: 'array',
+          },
+        },
+      ])
+
+      const emitted = [...schema]
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]!.name).toBe('concreteType')
+    })
+
+    test('inlines resolved type when referencing an effectively-unknown type', () => {
+      const schema = new SchemaTypeGenerator([
+        {
+          name: 'unknownArrayType',
+          type: 'type',
+          value: {
+            of: {of: [{type: 'unknown'}], type: 'union'},
+            type: 'array',
+          },
+        },
+        {
+          name: 'consumer',
+          type: 'type',
+          value: {
+            attributes: {
+              field: {
+                optional: true,
+                type: 'objectAttribute',
+                value: {name: 'unknownArrayType', type: 'inline'},
+              },
+            },
+            type: 'object',
+          },
+        },
+      ])
+
+      const emitted = [...schema]
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]!.name).toBe('consumer')
+
+      const code = generateCode(emitted[0]!.tsType)
+      expect(code).not.toContain('UnknownArrayType')
+      expect(code).toContain('unknown')
+    })
+
     test('generates TS Types for inline types', () => {
       const schema = new SchemaTypeGenerator([
         {
@@ -354,12 +655,9 @@ describe(SchemaTypeGenerator.name, () => {
       ])
 
       const inlineAlias = schema.getType('inlineAlias')?.tsType
-      const inlineAliasWithNoMatchingType = schema.getType('inlineAliasWithNoMatchingType')?.tsType
 
       expect(generateCode(inlineAlias)).toMatchInlineSnapshot(`"Person"`)
-      expect(generateCode(inlineAliasWithNoMatchingType)).toMatchInlineSnapshot(
-        `"unknown // Unable to locate the referenced type "noMatchingType" in schema"`,
-      )
+      expect(schema.getType('inlineAliasWithNoMatchingType')).toBeUndefined()
     })
 
     test('quotes non-identifier keys, preserves valid identifier keys', () => {
@@ -497,11 +795,7 @@ describe(SchemaTypeGenerator.name, () => {
       ])
 
       const objectAlias = schema.getType('objectAlias')?.tsType
-      const objectWithUnknownRest = schema.getType('objectWithUnknownRest')?.tsType
       const objectWithInlineRest = schema.getType('objectWithInlineRest')?.tsType
-      const objectWithUnresolvableInlineRest = schema.getType(
-        'objectWithUnresolvableInlineRest',
-      )?.tsType
       const objectWithObjectRest = schema.getType('objectWithObjectRest')?.tsType
       const dereferenceableObject = schema.getType('dereferenceableObject')?.tsType
 
@@ -510,7 +804,7 @@ describe(SchemaTypeGenerator.name, () => {
           name: string;
         }"
       `)
-      expect(generateCode(objectWithUnknownRest)).toMatchInlineSnapshot(`"unknown"`)
+      expect(schema.getType('objectWithUnknownRest')).toBeUndefined()
       expect(generateCode(objectWithInlineRest)).toMatchInlineSnapshot(
         `
         "{
@@ -518,9 +812,7 @@ describe(SchemaTypeGenerator.name, () => {
         } & Person"
       `,
       )
-      expect(generateCode(objectWithUnresolvableInlineRest)).toMatchInlineSnapshot(
-        `"unknown // Unable to locate the referenced type "unresolvableInlineRest" in schema"`,
-      )
+      expect(schema.getType('objectWithUnresolvableInlineRest')).toBeUndefined()
       expect(generateCode(objectWithObjectRest)).toMatchInlineSnapshot(`
         "{
           name: string;

--- a/src/typescript/schemaTypeGenerator.ts
+++ b/src/typescript/schemaTypeGenerator.ts
@@ -62,6 +62,34 @@ export class SchemaTypeGenerator {
     for (const type of schema) {
       this.tsTypes.set(type.name, this.generateTsType(type))
     }
+
+    let hasEffectivelyUnknownTypes = false
+    for (const type of schema) {
+      const tsType = this.tsTypes.get(type.name)
+      if (tsType && SchemaTypeGenerator.isEffectivelyUnknown(tsType)) {
+        this.identifiers.delete(type.name)
+        hasEffectivelyUnknownTypes = true
+      }
+    }
+
+    if (hasEffectivelyUnknownTypes) {
+      for (const type of schema) {
+        this.tsTypes.set(type.name, this.generateTsType(type))
+      }
+    }
+  }
+
+  private static isEffectivelyUnknown(tsType: t.TSType): boolean {
+    if (t.isTSUnknownKeyword(tsType)) return true
+    if (
+      t.isTSTypeReference(tsType) &&
+      t.isIdentifier(tsType.typeName) &&
+      tsType.typeParameters?.params.length === 1 &&
+      t.isTSUnknownKeyword(tsType.typeParameters.params[0])
+    ) {
+      return true
+    }
+    return false
   }
 
   getType(typeName: string): {id: t.Identifier; tsType: t.TSType} | undefined {
@@ -81,7 +109,8 @@ export class SchemaTypeGenerator {
 
   *[Symbol.iterator]() {
     for (const {name} of this.schema) {
-      yield {name, ...this.getType(name)!}
+      const type = this.getType(name)
+      if (type) yield {name, ...type}
     }
   }
 
@@ -144,17 +173,17 @@ export class SchemaTypeGenerator {
 
   private generateInlineTsType(typeNode: InlineTypeNode): t.TSType {
     const id = this.identifiers.get(typeNode.name)
-    if (!id) {
-      // Not found in schema, return unknown type
-      return t.addComment(
-        t.tsUnknownKeyword(),
-        'trailing',
-        ` Unable to locate the referenced type "${typeNode.name}" in schema`,
-        true,
-      )
-    }
+    if (id) return t.tsTypeReference(id)
 
-    return t.tsTypeReference(id)
+    const resolvedType = this.tsTypes.get(typeNode.name)
+    if (resolvedType) return t.cloneNode(resolvedType, true)
+
+    return t.addComment(
+      t.tsUnknownKeyword(),
+      'trailing',
+      ` Unable to locate the referenced type "${typeNode.name}" in schema`,
+      true,
+    )
   }
 
   // Helper function used to generate TS types for object type nodes.
@@ -274,8 +303,13 @@ export class SchemaTypeGenerator {
   // Helper function used to generate TS types for union type nodes.
   private generateUnionTsType(typeNode: UnionTypeNode): t.TSType {
     if (typeNode.of.length === 0) return t.tsNeverKeyword()
-    if (typeNode.of.length === 1) return this.generateTsType(typeNode.of[0]!)
-    return t.tsUnionType(typeNode.of.map((node) => this.generateTsType(node)))
+
+    const generated = typeNode.of.map((node) => this.generateTsType(node))
+    const nonUnknown = generated.filter((tsType) => !t.isTSUnknownKeyword(tsType))
+
+    if (nonUnknown.length === 0) return t.tsUnknownKeyword()
+    if (nonUnknown.length === 1) return nonUnknown[0]!
+    return t.tsUnionType(nonUnknown)
   }
 }
 


### PR DESCRIPTION
### Description

Fix union type collapse caused by `unknown` members poisoning entire union types.

When generating TypeScript types from a schema, objects with unresolvable inline `rest` references (e.g. `rest: {type: "inline", name: "someType"}` where `someType` isn't in the schema) collapse to `unknown`. When these `unknown` members appear in a union alongside concrete types, TypeScript simplifies `ConcreteType | unknown` to just `unknown`, destroying all type information for the entire union.

On our marketing website, this caused `BlockContent` to be generated with bare `unknown` entries mixed in with concrete types — and because `T | unknown = unknown` in TypeScript, this made `BlockContent` effectively `unknown[]`, losing all type safety:

```diff
 export type BlockContent = Array<
   | ({ _key: string } & ArticleSectionReference)
   | ({ _key: string } & CtaCollection)
   | ({ _key: string } & Codesandbox)
   | ({ _key: string } & ExploreBlock)
   | ({ _key: string } & GettingStartedBlock)
   | ({ _key: string } & Gist)
-  | unknown
-  | unknown
-  | unknown
   | ({ _key: string } & LinkBlockWithImage)
   | ({ _key: string } & MuxVideo_2)
   // ...
```

Tested on the marketing website repo with `pnpm.overrides["@sanity/codegen"]: "6.0.3-canary.0"` — `BlockContent` and other affected types are now generated correctly with the unknown entries filtered out.

Additionally, type aliases that resolve entirely to `unknown` or `Array<unknown>` (e.g. `export type SimpleBlockContent = unknown[]`) are no longer emitted. Instead, their resolved type is inlined at usage sites, making it clear there's no real type information rather than hiding it behind a named alias.

**Changes to `schemaTypeGenerator.ts`:**
- `generateUnionTsType`: generates all members first, then filters out any that resolved to `TSUnknownKeyword`. Catches all sources of unknown (direct nodes, collapsed objects, nested unions).
- `isEffectivelyUnknown`: static helper that identifies `unknown` and `Array<unknown>`/`ArrayOf<unknown>`.
- Constructor: two-pass generation — after the first pass, identifies effectively-unknown types, removes their identifiers, then regenerates so inline references produce inlined types instead of dangling named references.
- `generateInlineTsType`: new fallback path that clones and inlines the resolved type when the identifier was removed but the type exists in the map.
- Iterator: skips types where `getType` returns `undefined` (effectively-unknown types).

### What to review

- `src/typescript/schemaTypeGenerator.ts` — all changes are in this file
- The union filtering logic in `generateUnionTsType` — verify it correctly preserves concrete types while filtering unknowns
- The two-pass constructor — verify the regeneration pass correctly resolves inline references to suppressed types
- The `isEffectivelyUnknown` helper — verify the `Array<unknown>` / `ArrayOf<unknown>` detection is correct
- Check that the iterator change doesn't break consumers that expect all schema types to be yielded (the `typeGenerator.ts` consumer builds `AllSanitySchemaTypes` from the same iterator, which should also exclude unknown types)

### Testing

Added 6 new tests and updated 3 existing tests in `schemaTypeGenerator.test.ts`:

- **Union with `string | unknown | number | unknown`** → produces `string | number`
- **Union of all unknowns** → not emitted (effectively unknown)
- **BlockContent-style union**: array of union where some objects have unresolvable inline rests (`infoBox`, `gotcha`, `protip` not in schema) alongside concrete types (`ctaCollection`, `gist`, block) → unknown members filtered, concrete types preserved, no `unknown` in output
- **Objects with unresolvable inline rest** collapse to unknown → filtered from parent union, concrete siblings preserved
- **Type resolving to `unknown`** → not yielded by iterator, `getType` returns `undefined`
- **Type resolving to `Array<unknown>`** → not yielded by iterator
- **Inline ref to effectively-unknown type** → resolved type inlined instead of named reference
- Existing tests for `unknownAlias`, `objectWithUnknownRest`, `objectWithUnresolvableInlineRest`, and `inlineAliasWithNoMatchingType` updated to expect `undefined` from `getType`

Also tested manually on the marketing website repo by adding `pnpm.overrides["@sanity/codegen"]: "6.0.3-canary.0"` and verifying `BlockContent` and other affected types are generated correctly.
