### PR TITLE
fix(typegen): emit ArrayOf helper when only queries reference it

### DIFF
--- a/src/typescript/__tests__/typeGenerator.test.ts
+++ b/src/typescript/__tests__/typeGenerator.test.ts
@@ -932,6 +932,111 @@ describe(TypeGenerator.name, () => {
     `)
   })
 
+  test('ArrayOf declaration is emitted when only queries (not schema) reference it', async () => {
+    // Regression: a schema that mixes a nested union-of-inline with other
+    // (non-inline) union members renders as `Array<...>` (no ArrayOf), but a
+    // query that filters/projects the array down to the inline branch produces
+    // `ArrayOf<...>` in the emitted query type. If the gate only inspects
+    // schema-side usage, the helper declaration is skipped while usages remain
+    // → TS2304 "Cannot find name 'ArrayOf'".
+    const schema: SchemaType = [
+      {
+        name: 'blockA',
+        type: 'type',
+        value: {
+          attributes: {
+            _type: {type: 'objectAttribute', value: {type: 'string', value: 'blockA'}},
+            a: {optional: true, type: 'objectAttribute', value: {type: 'string'}},
+          },
+          type: 'object',
+        },
+      },
+      {
+        name: 'blockB',
+        type: 'type',
+        value: {
+          attributes: {
+            _type: {type: 'objectAttribute', value: {type: 'string', value: 'blockB'}},
+            b: {optional: true, type: 'objectAttribute', value: {type: 'string'}},
+          },
+          type: 'object',
+        },
+      },
+      {
+        attributes: {
+          _id: {type: 'objectAttribute', value: {type: 'string'}},
+          _type: {type: 'objectAttribute', value: {type: 'string', value: 'post'}},
+          // `items` is an array whose member is a union of:
+          //   (a) a nested union of inline named types
+          //   (b) an anonymous object
+          // Outer union has no top-level `inline` members, so schema-side renders
+          // as `Array<...>` (no ArrayOf). Real-world Sanity schemas hit this
+          // shape whenever an array attribute mixes references / typed refs with
+          // anonymous inline objects (common for tables of contents, link
+          // lists, portable-text-like block arrays, etc.).
+          items: {
+            optional: true,
+            type: 'objectAttribute',
+            value: {
+              of: {
+                of: [
+                  {
+                    of: [
+                      {name: 'blockA', type: 'inline'},
+                      {name: 'blockB', type: 'inline'},
+                    ],
+                    type: 'union',
+                  },
+                  {
+                    attributes: {
+                      _type: {type: 'objectAttribute', value: {type: 'string', value: 'note'}},
+                      note: {optional: true, type: 'objectAttribute', value: {type: 'string'}},
+                    },
+                    type: 'object',
+                  },
+                ],
+                type: 'union',
+              },
+              type: 'array',
+            },
+          },
+        },
+        name: 'post',
+        type: 'document',
+      },
+    ]
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    async function* getQueries(): AsyncGenerator<ExtractedModule> {
+      yield {
+        errors: [],
+        filename: '/src/foo.ts',
+        queries: [
+          {
+            filename: '/src/foo.ts',
+            // Filtering down to only inline-typed members produces `Array<inline>`
+            // in the query result → ArrayOf<BlockA | BlockB> in the emitted type.
+            query: '*[_type == "post"]{ "blocks": items[_type == "blockA" || _type == "blockB"] }',
+            variable: {id: {name: 'queryPosts', type: 'Identifier'}},
+          },
+        ],
+      }
+    }
+
+    const typeGenerator = new TypeGenerator()
+    const {code} = await typeGenerator.generateTypes({
+      overloadClientMethods: false,
+      queries: getQueries(),
+      root: '/src',
+      schema,
+    })
+
+    // Sanity check that the repro actually exercises ArrayOf in a query type.
+    expect(code).toContain('ArrayOf<')
+    // The bug: code references ArrayOf<...> but never declares it.
+    expect(code).toContain('type ArrayOf<T> = Array<T & {')
+  })
+
   test('ArrayOf should NOT be generated when not used (no inline type references)', async () => {
     const schema: SchemaType = [
       {

--- a/src/typescript/typeGenerator.ts
+++ b/src/typescript/typeGenerator.ts
@@ -286,6 +286,16 @@ export class TypeGenerator {
       schemaTypeDeclarations,
     })
 
+    // Queries can produce `inline` type nodes that the schema-side generator
+    // never sees (e.g. filtering a tagged-union array down to its inline
+    // members). Evaluate modules before deciding whether the ArrayOf helper is
+    // needed, so query-only usage still triggers the declaration.
+    const evaluatedModules = await TypeGenerator.getEvaluatedModules({
+      ...options,
+      schemaTypeDeclarations,
+      schemaTypeGenerator,
+    })
+
     const program = t.program([])
     let code = ''
 
@@ -305,12 +315,6 @@ export class TypeGenerator {
 
     program.body.push(allSanitySchemaTypesDeclaration.ast)
     code += allSanitySchemaTypesDeclaration.code
-
-    const evaluatedModules = await TypeGenerator.getEvaluatedModules({
-      ...options,
-      schemaTypeDeclarations,
-      schemaTypeGenerator,
-    })
 
     for (const {queries} of evaluatedModules) {
       for (const query of queries) {


### PR DESCRIPTION
## Summary

Fixes #113.

The gate added in #40 to only emit the `ArrayOf<T>` helper when referenced inspects schema-side usage only. But `SchemaTypeGenerator.arrayOfUsed` is *also* mutated by `evaluateQuery()`, and query evaluation runs **after** the gate. So any query-only `ArrayOf<...>` reference ends up in the generated file without its declaration — the user sees hundreds of `TS2304: Cannot find name 'ArrayOf'` errors.

Fix is one-line in intent: evaluate modules before the gate runs. Output order is unchanged.

## Repro

Schema where the array element is a union containing a nested union-of-inline (no `inline` at the top level of the outer union) renders as `Array<…>` (no `ArrayOf`). A query that filters down to the inline branch produces `ArrayOf<…>` in the query result type. This pattern is extremely common in real-world Sanity schemas — portable-text-like blocks, link arrays, tables of contents that mix references / typed refs with anonymous objects all hit it.

Concrete numbers: one real project produces **755 `ArrayOf<...>` references and zero declarations** on `@sanity/codegen@6.0.3`.

A minimal failing case is included as a regression test in `src/typescript/__tests__/typeGenerator.test.ts`.

## Why this approach

Three options were on the table:

1. **Move query evaluation before the gate (this PR).** Smallest, preserves output order, no behavior change for schemas that don't have query-only `ArrayOf` usage.
2. Always emit the declaration and strip it as a final unused-helper pass. Cleaner long-term but a bigger change and would address #34 differently.
3. Track `ArrayOf` usage on the emitted AST instead of a counter on the generator. Cleanest, but a bigger refactor.

Option 1 is the minimal correct patch.

## Test plan

- [x] New regression test fails on `main`, passes with this change
- [x] Pre-existing `ArrayOf` tests still pass (3 ArrayOf-related tests, all green)
- [x] Full test suite passes locally except 2 pre-existing CLI-watch-mode failures that also fail on `main` in this environment (`command typegen:generate not found` — needs the built oclif manifest)
- [x] Verified end-to-end on a real project: patched `dist/typescript/typeGenerator.js` over the installed copy, re-ran `sanity typegen generate` — the file now has `type ArrayOf<T> = Array<T & { _key: string }>` at the top, all 755 usages resolve.

## Notes

- The new `getEvaluatedModules` call now happens slightly earlier in the function. The `report.event.generatedSchemaTypes` and `report.event.generatedQueryTypes` events still fire in the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)