### PR TITLE
ci: add pkg.pr.new continuous releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,37 @@
+name: Continuous Releases
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish
+        run: pnpm exec pkg-pr-new publish --no-template

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lint-staged": "^16.4.0",
     "oclif": "^4.23.10",
     "oxfmt": "^0.53.0",
+    "pkg-pr-new": "^0.0.75",
     "prettier-plugin-packagejson": "^3.0.2",
     "rimraf": "^5.0.10",
     "tinyglobby": "^0.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       oxfmt:
         specifier: ^0.53.0
         version: 0.53.0
+      pkg-pr-new:
+        specifier: ^0.0.75
+        version: 0.0.75
       prettier-plugin-packagejson:
         specifier: ^3.0.2
         version: 3.0.2(prettier@3.8.3)
@@ -6062,6 +6065,10 @@ packages:
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
     engines: {node: '>=6'}
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -13927,6 +13934,8 @@ snapshots:
   pkg-dir@3.0.0:
     dependencies:
       find-up: 3.0.0
+
+  pkg-pr-new@0.0.75: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
Publishes a continuous release to [pkg.pr.new](https://pkg.pr.new) on every push to `main` and on every pull request, so changes can be installed and tested before they are formally released.

This mirrors the setup in `groq-js`, adapted to this repo's conventions:

- Uses pnpm (`pnpm/action-setup@v5`, `pnpm install --frozen-lockfile`, `pnpm build`) rather than npm.
- Uses `actions/checkout@v6` and `actions/setup-node@v6` to match the existing `test.yml`.
- Triggers on `main` only (no `canary` branch here).
- Passes `--no-template` to disable the StackBlitz template comment.
- Uses a minimal `contents: read` token, since pkg.pr.new posts comments and check runs via its own GitHub App, not `GITHUB_TOKEN`.

`pkg-pr-new@^0.0.75` is added to devDependencies (matching `groq-js`) so the publish step resolves a pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)